### PR TITLE
Fix "How To Use" Section Sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can now add a `MapLocationPicker` widget to your widget tree. You can proces
 ```dart
 MapLocationPicker(onPicked: (result){
     // you can get the location result here
-    print(result.address);
+    print(result.completeAddress);
     print(result.latitude);
     print(result.longitude);
 })


### PR DESCRIPTION
"completeAddress" should be used instead of "address"